### PR TITLE
Fix travis CI: Class 'PHP_Timer' not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ composer.lock
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock
+/nbproject/
+/build/

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.12",
+    "phpunit/php-timer": "1.0.9",
     "satooshi/php-coveralls": "v1.0.1"
   },
   "autoload": {


### PR DESCRIPTION
Fix Travis CI PHP 7.1: Class 'PHP_Timer' not found

https://travis-ci.org/kittinan/php-promptpay-qr/jobs/341437133